### PR TITLE
Python3 compatibility

### DIFF
--- a/django_pglocks/__init__.py
+++ b/django_pglocks/__init__.py
@@ -1,6 +1,10 @@
 __version__ = '1.0.2'
 
 from contextlib import contextmanager
+from zlib import crc32
+
+from django.utils import six
+
 
 @contextmanager
 def advisory_lock(lock_id, shared=False, wait=True, using=None):
@@ -34,12 +38,20 @@ def advisory_lock(lock_id, shared=False, wait=True, using=None):
         if len(lock_id) != 2:
             raise ValueError("Tuples and lists as lock IDs must have exactly two entries.")
 
-        if not isinstance(lock_id[0], (int, long,)) or not isinstance(lock_id[1], (int, long,)):
-            raise ValueError("Both members of a tuple/list lock ID must be ints or longs")
+        if not isinstance(lock_id[0], six.integer_types) or not isinstance(lock_id[1], six.integer_types):
+            raise ValueError("Both members of a tuple/list lock ID must be integers")
 
         tuple_format = True
-    elif not isinstance(lock_id, (int, long,)):
-        lock_id = long(lock_id.__hash__())
+    elif isinstance(lock_id, six.string_types):
+        # Generates an id within postgres integer range (-2^31 to 2^31 - 1).
+        # crc32 generates an unsigned integer in Py3, we convert it into
+        # a signed integer using 2's complement (this is a noop in Py2)
+        pos = crc32(lock_id.encode("utf-8"))
+        lock_id = (2**31 - 1) & pos
+        if pos & 2**31:
+            lock_id -= 2**31
+    elif not isinstance(lock_id, six.integer_types):
+        raise ValueError("Cannot use %s as a lock id" % lock_id)
 
     if tuple_format:
         base = "SELECT %s(%d, %d)"

--- a/django_pglocks/tests.py
+++ b/django_pglocks/tests.py
@@ -24,9 +24,23 @@ class PgLocksTests(TransactionTestCase):
         cursor.close()
         self.assertEqual(actual, expected)
 
-    def test_basic_lock(self):
+    def test_basic_lock_str(self):
         self.assertNumLocks(0)
         with advisory_lock('test') as acquired:
+            self.assertTrue(acquired)
+            self.assertNumLocks(1)
+        self.assertNumLocks(0)
+
+    def test_basic_lock_int(self):
+        self.assertNumLocks(0)
+        with advisory_lock(123) as acquired:
+            self.assertTrue(acquired)
+            self.assertNumLocks(1)
+        self.assertNumLocks(0)
+
+    def test_basic_lock_tuple(self):
+        self.assertNumLocks(0)
+        with advisory_lock(123, 456) as acquired:
             self.assertTrue(acquired)
             self.assertNumLocks(1)
         self.assertNumLocks(0)


### PR DESCRIPTION
This pull request makes django-pglocks compatible with Python 3 (tested with Python 3.3 + Django 1.7).

Note that `__hash__()` should not be used to construct the lock id as it is randomized in Python 3 (see https://docs.python.org/3/reference/datamodel.html#object.__hash__).
