### PR TITLE
Add tox.ini and add python 3 classifiers.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -55,7 +55,7 @@ The parameters are:
 Contributing
 ============
 
-To run the test suite, you must create a user and a database::
+To run the test suite, you must create a user and a database, and install `tox <https://pypi.python.org/pypi/tox>`_::
 
     $ createuser -s -P django_pglocks
     Enter password for new role: django_pglocks
@@ -64,7 +64,7 @@ To run the test suite, you must create a user and a database::
 
 You can then run the tests with::
 
-    $ DJANGO_SETTINGS_MODULE=django_pglocks.test_settings PYTHONPATH=. django-admin.py test
+    $ tox
 
 License
 =======

--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,10 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Topic :: Software Development',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3',
+        'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,15 @@
+[tox]
+envlist = {py27,py34,py35}-{1.8,1.9,1.10}
+
+[testenv]
+usedevelop = True
+setenv =
+  DJANGO_SETTINGS_MODULE=django_pglocks.test_settings
+  PYTHONPATH=.
+commands =
+  django-admin.py test
+deps =
+  psycopg2
+  1.8: Django>=1.8,<1.9
+  1.9: Django>=1.9,<1.10
+  1.10: Django>=1.10,<1.11


### PR DESCRIPTION
@Xof Updates the packaging metadata data so the package will show up as  Python 3 compatible to tools like `caniusepython3`. I also added a `tox.ini` file for running the test suite, and verified that it passes across Django 1.8-1.10 and Python 2.7, 3.4, and 3.5.

Thanks for writing this very useful library!
