### PR TITLE
Add tox support

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -3,3 +3,6 @@ CHANGES.txt
 LICENSE.txt
 setup.py
 django_pglocks/__init__.py
+django_pglocks/models.py
+django_pglocks/test_settings.py
+django_pglocks/tests.py

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ To run the test suite, you must create a user and a database::
 
 You can then run the tests with::
 
-    $ DJANGO_SETTINGS_MODULE=django_pglocks.test_settings PYTHONPATH=. django-admin.py test
+    $ tox
 
 License
 =======

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,19 @@
+[tox]
+envlist = {py27,py34,py35,py36}-django{18,19,110,111}
+[testenv]
+basepython =
+    py27: python2.7
+    py34: python3.4
+    py35: python3.5
+    py36: python3.6
+deps=
+    django18: Django>=1.8,<1.9
+    django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2
+    psycopg2
+setenv =
+    DJANGO_SETTINGS_MODULE=django_pglocks.test_settings
+    PYTHONPATH=.
+commands=django-admin.py test
+


### PR DESCRIPTION
tox configuration to run tests against django 1.8 through 1.11 and python 2.7, 3.4, 3.5 and 3.6