### PR TITLE
Add Programming Language classifiers

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -35,5 +35,8 @@ setup(
         'Intended Audience :: Developers',
         'License :: OSI Approved :: MIT License',
         'Topic :: Software Development',
+        'Programming Language :: Python',
+        'Programming Language :: Python :: 2',
+        'Programming Language :: Python :: 3',
     ]
 )


### PR DESCRIPTION
Same as #16 but without the tox dependency. It allows tools like `caniusepython3` or `pip` to tell that this library is compatible with Python 3.