### PR TITLE
Add Django 3.0 compatibility

### DIFF
--- a/django_pglocks/__init__.py
+++ b/django_pglocks/__init__.py
@@ -6,8 +6,8 @@ from zlib import crc32
 @contextmanager
 def advisory_lock(lock_id, shared=False, wait=True, using=None):
 
+    import six
     from django.db import DEFAULT_DB_ALIAS, connections, transaction
-    from django.utils import six
 
     if using is None:
         using = DEFAULT_DB_ALIAS

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
     author_email = "xof@thebuild.com",
     license = "MIT",
     url = "https://github.com/Xof/django-pglocks",
+    install_requires = ['six>=1.0.0'],
     packages = [
         'django_pglocks',
     ],


### PR DESCRIPTION
This fixes compatibility with Django 3.0.

`django.utils.six` was removed from Django so this adds an explicit dependency on six and imports it directly.