### PR TITLE
Retarget 2.1.0 deprecation to django-pgware

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,12 +1,13 @@
 # Changelog
 
-## 2.1.0 (2026-04-04)
+## 2.1.0 (2026-06-20)
 
-**Final release — this package has been consolidated into [django-pg-utils](https://github.com/Xof/django-pg-utils).**
+**Final release — this package has been consolidated into [django-pgware](https://github.com/Xof/django-pgware).**
 
-This version is a compatibility shim that depends on `django-pg-utils` and re-exports
-`advisory_lock` and `async_advisory_lock` with a deprecation warning. No further updates
-will be made to this package.
+This version is a compatibility shim that depends on `django-pgware` (installed as
+`django-pgware`, imported as `django_pg_utils`) and re-exports `advisory_lock` and
+`async_advisory_lock` with a deprecation warning. No further updates will be made to
+this package.
 
 ## 2.0.0 (2026-04-02)
 

--- a/README.md
+++ b/README.md
@@ -1,16 +1,20 @@
 # django-pglocks
 
-> **This package has been consolidated into [django-pg-utils](https://github.com/Xof/django-pg-utils).**
+> **This package is deprecated.** Its functionality has moved to
+> **[django-pgware](https://github.com/Xof/django-pgware)**.
 >
-> Install `django-pg-utils` and update your imports:
+> ```bash
+> pip install django-pgware
+> ```
 >
 > ```python
 > # Old:
 > from django_pglocks import advisory_lock
 >
-> # New:
-> from django_pg_utils.locks import advisory_lock
+> # New (django-pgware installs as `django-pgware`, imports as `django_pg_utils`):
+> from django_pg_utils import advisory_lock
 > ```
 >
-> This package (2.1.0) is a compatibility shim that re-exports from `django-pg-utils`.
+> This package (2.1.0) is a final compatibility shim: it depends on `django-pgware`
+> and re-exports `advisory_lock`/`async_advisory_lock` with a `DeprecationWarning`.
 > It will not receive further updates.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "django-pglocks"
 version = "2.1.0"
-description = "Context managers for PostgreSQL advisory locks in Django."
+description = "DEPRECATED — consolidated into django-pgware. Context managers for PostgreSQL advisory locks in Django."
 readme = "README.md"
 license = "MIT"
 requires-python = ">=3.10"
@@ -34,7 +34,7 @@ classifiers = [
 # one yourself — Django needs it too, so you almost certainly already have one.
 dependencies = [
     "django>=4.2",
-    "django-pg-utils>=0.1.0",
+    "django-pgware>=1.0.0",
 ]
 
 [project.urls]

--- a/src/django_pglocks/__init__.py
+++ b/src/django_pglocks/__init__.py
@@ -1,8 +1,9 @@
 import warnings
 
 warnings.warn(
-    "django-pglocks has been consolidated into django-pg-utils. "
-    "Install django-pg-utils and update imports to django_pg_utils.locks. "
+    "django-pglocks has been consolidated into django-pgware. "
+    "Install django-pgware (it imports as django_pg_utils) and update "
+    "imports to django_pg_utils.locks. "
     "This compatibility package will not receive further updates.",
     DeprecationWarning,
     stacklevel=2,


### PR DESCRIPTION
## What

The `django-pglocks` 2.1.0 final/shim release pointed at **django-pg-utils**, but the actual successor published on PyPI is **[django-pgware 1.0.0](https://pypi.org/project/django-pgware/)**. This corrects every distribution-name reference.

## Changes

- **pyproject.toml** — dependency `django-pg-utils>=0.1.0` → `django-pgware>=1.0.0`; `Summary` now leads with `DEPRECATED — consolidated into django-pgware` so the deprecation is visible in PyPI search results and the page header.
- **src/django_pglocks/__init__.py** — `DeprecationWarning` text retargeted to django-pgware.
- **README.md** — banner rewritten to point at django-pgware, with the install-vs-import-name caveat.
- **CHANGELOG.md** — 2.1.0 entry retargeted; date set to 2026-06-20.

## Notes

- **No version bump.** PyPI's latest published `django-pglocks` is 1.0.4; the committed 2.0.0/2.1.0 were never uploaded, so 2.1.0 is corrected in place.
- **Import path unchanged.** The shim keeps `from django_pg_utils.locks import …` — django-pgware installs under that distribution name but ships the `django_pg_utils` module, so the import resolves once it's installed.
- The `Development Status :: 7 - Inactive` classifier was already present.

## Verified

`uv build` produces a clean 2.1.0 wheel with `Summary: DEPRECATED…`, `Requires-Dist: django-pgware>=1.0.0`, and `Classifier: Development Status :: 7 - Inactive`.