### PR TITLE
Add 2.1.0 release notes

### DIFF
--- a/RELEASE_NOTES_v2.1.0.md
+++ b/RELEASE_NOTES_v2.1.0.md
@@ -1,0 +1,27 @@
+## django-pglocks 2.1.0 — Final release
+
+**This package is deprecated.** Its functionality now lives in
+**[django-pgware](https://pypi.org/project/django-pgware/)**.
+
+2.1.0 is a final compatibility shim: it depends on `django-pgware` and
+re-exports `advisory_lock` / `async_advisory_lock` with a `DeprecationWarning`.
+No further updates will be made here.
+
+### Migrate
+
+```bash
+pip install django-pgware
+```
+
+```python
+# Old:
+from django_pglocks import advisory_lock
+# New (django-pgware installs as `django-pgware`, imports as `django_pg_utils`):
+from django_pg_utils import advisory_lock
+```
+
+### Notes
+
+- Marked `Development Status :: 7 - Inactive` on PyPI.
+- The PyPI summary now leads with `DEPRECATED`.
+- Last functional release was 1.0.4; 2.x is shim-only.


### PR DESCRIPTION
Adds `RELEASE_NOTES_v2.1.0.md` for the upcoming final release.

Consumed by `gh release create v2.1.0 --notes-file RELEASE_NOTES_v2.1.0.md`,
which triggers the trusted-publishing workflow to PyPI. Standalone markdown —
no code dependency on [#33](https://github.com/Xof/django-pglocks/pull/33), so it can merge independently.