### PR TITLE
Drop the broken TestPyPI publish job

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,3 +1,7 @@
+# Publishes to PyPI via trusted publishing (OIDC) on a published GitHub Release.
+# There is deliberately no TestPyPI step: the django-pglocks name on TestPyPI is
+# held by an unrelated account, so trusted publishing there is impossible. Pre-release
+# validation is done locally instead (uv build + twine check).
 name: Publish
 
 on:
@@ -36,24 +40,6 @@ jobs:
         with:
           name: dist
           path: dist/
-
-  publish-testpypi:
-    needs: build
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
-    runs-on: ubuntu-latest
-    environment: testpypi
-    permissions:
-      id-token: write
-    steps:
-      - uses: actions/download-artifact@v4
-        with:
-          name: dist
-          path: dist/
-
-      - name: Publish to TestPyPI
-        uses: pypa/gh-action-pypi-publish@release/v1
-        with:
-          repository-url: https://test.pypi.org/legacy/
 
   publish-pypi:
     needs: build


### PR DESCRIPTION
The `django-pglocks` name on TestPyPI is held by an unrelated account, so the trusted-publishing token exchange always fails (`invalid-publisher`) and the `publish-testpypi` job red-Xed on every tag push. There's no way to claim a name someone else holds, and TestPyPI is only a dry-run.

## Change
- Remove the `publish-testpypi` job from `publish.yml`. `build` + `publish-pypi` (on a published Release) remain — the real release path is unaffected.
- Add a header comment explaining why there's no TestPyPI step.

Pre-release validation is done locally instead (`uv build` + `twine check`), which is exactly how 2.1.0 was verified before it shipped.